### PR TITLE
Fix error 500

### DIFF
--- a/app/models/utils.php
+++ b/app/models/utils.php
@@ -12,7 +12,7 @@ use Symfony\Component\Finder\SplFileInfo;
  *
  * @return int The calculated size
  */
-function get_size(SplFileInfo $file) {
+function get_size(\SplFileInfo $file) {
 
     $size = 0;
 


### PR DESCRIPTION
J'avais une erreur remonté dans le fichier log, ceci a permis de corriger le problème.
PHP Catchable fatal error:  Argument 1 passed to App\\Models\\Utils\\get_size() must be an instance of Symfony\\Component\\Finder\\SplFileInfo, instance of SplFileInfo given,