### PR TITLE
Update apache2-alias.conf.example

### DIFF
--- a/webconf-example/apache2-alias.conf.example
+++ b/webconf-example/apache2-alias.conf.example
@@ -1,4 +1,3 @@
-<VirtualHost *:80>
     Alias /$ALIAS $CAKEBOXREP/public/
     <Directory $CAKEBOXREP/public/>
         Options Indexes MultiViews FollowSymLinks
@@ -41,5 +40,4 @@
 
     ErrorLog "/var/log/apache2/$ALIAS-error.log"
     CustomLog "/var/log/apache2/$ALIAS-access.log" common
-</VirtualHost>
 


### PR DESCRIPTION
Retrait des balises <virtualhost *80> et <virtualhost> en début et fin de fichier causant une erreur 404 lors du chargement de cakebox et tronquant la possibilité de se connecter via l'alias